### PR TITLE
Implemented blue/green functionality

### DIFF
--- a/src/Command/Index.php
+++ b/src/Command/Index.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient;
+use Valantic\ElasticaBridgeBundle\Exception\Index\BlueGreenIndicesIncorrectlySetupException;
 use Valantic\ElasticaBridgeBundle\Index\IndexInterface;
 use Valantic\ElasticaBridgeBundle\Repository\IndexDocumentRepository;
 use Valantic\ElasticaBridgeBundle\Repository\IndexRepository;
@@ -82,21 +83,31 @@ class Index extends BaseCommand
             }
 
             $index = $this->esClient->getIndex($indexConfig->getName());
+            $currentIndex = $index;
+            $this->ensureCorrectIndexSetup($indexConfig);
 
-            if (!$this->input->getOption(self::OPTION_NO_DELETE)) {
-                $this->ensureIndexExists($index, $indexConfig);
+            if ($indexConfig->usesBlueGreenIndices()) {
+                $currentIndex = $indexConfig->getBlueGreenInactiveElasticaIndex();
             }
 
             if (!$this->input->getOption(self::OPTION_NO_POPULATE)) {
-                $this->populateIndex($indexConfig, $index);
+                $this->populateIndex($indexConfig, $currentIndex);
 
-                $index->refresh();
-                $indexCount = $index->count();
+                $currentIndex->refresh();
+                $indexCount = $currentIndex->count();
                 $this->output->writeln('> ' . $indexCount . ' documents');
 
                 if ($indexCount > 0 && !$this->input->getOption(self::OPTION_NO_CHECK)) {
-                    $this->checkRandomDocument($index, $indexConfig);
+                    $this->checkRandomDocument($currentIndex, $indexConfig);
                 }
+            }
+            if ($indexConfig->usesBlueGreenIndices()) {
+                $activeIndex = $indexConfig->getBlueGreenActiveElasticaIndex();
+                $inactiveIndex = $indexConfig->getBlueGreenInactiveElasticaIndex();
+
+                $activeIndex->removeAlias($indexConfig->getName());
+                $activeIndex->flush();
+                $inactiveIndex->addAlias($indexConfig->getName());
             }
         }
 
@@ -154,15 +165,53 @@ class Index extends BaseCommand
         $this->output->writeln('');
     }
 
-    protected function ensureIndexExists(ElasticaIndex $index, IndexInterface $indexConfig): void
+    protected function ensureCorrectIndexSetup(IndexInterface $indexConfig): void
     {
-        if ($index->exists()) {
+        if ($indexConfig->usesBlueGreenIndices()) {
+            $this->ensureCorrectBlueGreenIndexSetup($indexConfig);
+
+            return;
+        }
+        $this->ensureCorrectSimpleIndexSetup($indexConfig);
+    }
+
+    protected function ensureCorrectSimpleIndexSetup(IndexInterface $indexConfig): void
+    {
+        $index = $indexConfig->getElasticaIndex();
+
+        if (!$this->input->getOption(self::OPTION_NO_DELETE) && $index->exists()) {
             $index->delete();
             $this->output->writeln('> Deleted index');
         }
 
-        $index->create($indexConfig->getCreateArguments());
-        $this->output->writeln('> Created index');
+        if (!$index->exists()) {
+            $index->create($indexConfig->getCreateArguments());
+            $this->output->writeln('> Created index');
+        }
+    }
+
+    protected function ensureCorrectBlueGreenIndexSetup(IndexInterface $indexConfig): void
+    {
+        $shouldDelete = !$this->input->getOption(self::OPTION_NO_DELETE);
+        foreach (IndexInterface::INDEX_SUFFIXES as $suffix) {
+            $name = $indexConfig->getName() . $suffix;
+            $aliasIndex = $this->esClient->getIndex($name);
+            if ($shouldDelete && $aliasIndex->exists()) {
+                $aliasIndex->delete();
+            }
+
+            if (!$aliasIndex->exists()) {
+                $aliasIndex->create($indexConfig->getCreateArguments());
+            }
+        }
+
+        try {
+            $indexConfig->getBlueGreenActiveSuffix();
+        } catch (BlueGreenIndicesIncorrectlySetupException $exception) {
+            $this->esClient->getIndex($indexConfig->getName() . IndexInterface::INDEX_SUFFIX_BLUE)->addAlias($indexConfig->getName());
+        }
+
+        $this->output->writeln('> Ensured indices are correctly set up with alias');
     }
 
     protected function checkRandomDocument(ElasticaIndex $index, IndexInterface $indexConfig): void

--- a/src/DocumentType/Index/DocumentRelationAwareDataObjectTrait.php
+++ b/src/DocumentType/Index/DocumentRelationAwareDataObjectTrait.php
@@ -20,7 +20,11 @@ trait DocumentRelationAwareDataObjectTrait
 
     public function shouldIndex(AbstractElement $element): bool
     {
-        $result = (Index::$isPopulating ? $this->index->getBlueGreenInactiveElasticaIndex() : $this->index->getElasticaIndex())
+        $result = (
+        Index::$isPopulating && $this->index->usesBlueGreenIndices()
+            ? $this->index->getBlueGreenInactiveElasticaIndex()
+            : $this->index->getElasticaIndex()
+        )
             ->search(
                 (new BoolQuery())
                     ->addFilter(new Match(IndexDocumentInterface::META_TYPE, IndexDocumentInterface::TYPE_DOCUMENT))

--- a/src/DocumentType/Index/DocumentRelationAwareDataObjectTrait.php
+++ b/src/DocumentType/Index/DocumentRelationAwareDataObjectTrait.php
@@ -5,6 +5,7 @@ namespace Valantic\ElasticaBridgeBundle\DocumentType\Index;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\Match;
 use Pimcore\Model\Element\AbstractElement;
+use Valantic\ElasticaBridgeBundle\Command\Index;
 use Valantic\ElasticaBridgeBundle\Index\IndexInterface;
 
 /**
@@ -19,11 +20,12 @@ trait DocumentRelationAwareDataObjectTrait
 
     public function shouldIndex(AbstractElement $element): bool
     {
-        $result = $this->index->getElasticaIndex()->search(
-            (new BoolQuery())
-                ->addFilter(new Match(IndexDocumentInterface::META_TYPE, IndexDocumentInterface::TYPE_DOCUMENT))
-                ->addFilter(new Match(IndexDocumentInterface::ATTRIBUTE_RELATED_OBJECTS, $element->getId()))
-        );
+        $result = (Index::$isPopulating ? $this->index->getBlueGreenInactiveElasticaIndex() : $this->index->getElasticaIndex())
+            ->search(
+                (new BoolQuery())
+                    ->addFilter(new Match(IndexDocumentInterface::META_TYPE, IndexDocumentInterface::TYPE_DOCUMENT))
+                    ->addFilter(new Match(IndexDocumentInterface::ATTRIBUTE_RELATED_OBJECTS, $element->getId()))
+            );
 
         return $result->count() > 0;
     }

--- a/src/Exception/Index/BlueGreenIndicesIncorrectlySetupException.php
+++ b/src/Exception/Index/BlueGreenIndicesIncorrectlySetupException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Valantic\ElasticaBridgeBundle\Exception\Index;
+
+use Valantic\ElasticaBridgeBundle\Exception\BaseException;
+
+class BlueGreenIndicesIncorrectlySetupException extends BaseException
+{
+    public function __construct()
+    {
+        parent::__construct('Blue-green indices are not set up correctly');
+    }
+}

--- a/src/Index/AbstractIndex.php
+++ b/src/Index/AbstractIndex.php
@@ -185,7 +185,7 @@ abstract class AbstractIndex implements IndexInterface
     {
         return array_reduce(
             array_map(
-                fn(string $suffix): bool => $this->client->getIndex($this->getName())->exists(),
+                fn(string $suffix): bool => $this->client->getIndex($this->getName().$suffix)->exists(),
                 self::INDEX_SUFFIXES
             ),
             fn(bool $item, bool $carry): bool => $item && $carry,

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -153,9 +153,13 @@ interface IndexInterface
      * When indexing DataObjects based on usage in Pimcore Documents, the index is queried during indexing.
      * In these instances, the index needs to be refreshed in order for newly-added data to be available immediately.
      *
+     * While populating is happening (as indicated by IndexCommand::$isPopulating), use the inactive index.
+     *
      * @return bool
      * @see DocumentNormalizerTrait::$relatedObjects
      * @see IndexCommand
+     * @see IndexCommand::$isPopulating
+     * @see IndexInterface::getBlueGreenInactiveElasticaIndex()
      */
     public function refreshIndexAfterEveryIndexDocumentWhenPopulating(): bool;
 

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -9,9 +9,23 @@ use Pimcore\Model\Element\AbstractElement;
 use Valantic\ElasticaBridgeBundle\Command\Index as IndexCommand;
 use Valantic\ElasticaBridgeBundle\DocumentType\Index\DocumentNormalizerTrait;
 use Valantic\ElasticaBridgeBundle\DocumentType\Index\IndexDocumentInterface;
+use Valantic\ElasticaBridgeBundle\Exception\Index\BlueGreenIndicesIncorrectlySetupException;
 
 interface IndexInterface
 {
+    /**
+     * The suffix for the blue index
+     */
+    public const INDEX_SUFFIX_BLUE = '--blue';
+    /**
+     * The suffix for the green index
+     */
+    public const INDEX_SUFFIX_GREEN = '--green';
+    /**
+     * List of valid index suffixes
+     */
+    public const INDEX_SUFFIXES = [self::INDEX_SUFFIX_BLUE, self::INDEX_SUFFIX_GREEN];
+
     /**
      * The name of the Elasticsearch index
      *
@@ -144,4 +158,59 @@ interface IndexInterface
      * @see IndexCommand
      */
     public function refreshIndexAfterEveryIndexDocumentWhenPopulating(): bool;
+
+    /**
+     * Indicates whether this index uses a blue-green setup to ensure re-populating the index doesn't result
+     * in a loss of functionality.
+     *
+     * @return bool
+     * @see IndexCommand
+     */
+    public function usesBlueGreenIndices(): bool;
+
+    /**
+     * Checks whether the blue and green indices are correctly set up.
+     *
+     * @return bool
+     * @internal
+     */
+    public function hasBlueGreenIndices(): bool;
+
+    /**
+     * Returns the currently active blue/green suffix.
+     *
+     * @return string
+     * @throws BlueGreenIndicesIncorrectlySetupException
+     * @internal
+     */
+    public function getBlueGreenActiveSuffix(): string;
+
+    /**
+     * Returns the currently inactive blue/green suffix.
+     *
+     * @return string
+     * @throws BlueGreenIndicesIncorrectlySetupException
+     * @internal
+     */
+    public function getBlueGreenInactiveSuffix(): string;
+
+    /**
+     * Returns the currently active blue/green Elastica index.
+     *
+     * @return Index
+     * @throws BlueGreenIndicesIncorrectlySetupException
+     * @see IndexInterface::getElasticaIndex()
+     * @internal
+     */
+    public function getBlueGreenActiveElasticaIndex(): Index;
+
+    /**
+     * Returns the currently inactive blue/green Elastica index.
+     *
+     * @return Index
+     * @throws BlueGreenIndicesIncorrectlySetupException
+     * @see IndexInterface::getElasticaIndex()
+     * @internal
+     */
+    public function getBlueGreenInactiveElasticaIndex(): Index;
 }


### PR DESCRIPTION
During indexing, a blue/green strategy is used to ensure errors during indexing don't result in a (potentially) empty index.

Simple i.e. non-blue/green indices are still possible, yet by default (in `AbstractIndex`) all indices will have blue/green enabled.

Since this is a breaking change, this will be released as part of `v0.2.0`.