### PR TITLE
Support object variants

### DIFF
--- a/src/DocumentType/AbstractDocument.php
+++ b/src/DocumentType/AbstractDocument.php
@@ -62,7 +62,7 @@ abstract class AbstractDocument implements DocumentInterface
 
     public function getListingClass(): string
     {
-        if ($this->getType() === DocumentInterface::TYPE_OBJECT || $this->getType() === DocumentInterface::TYPE_VARIANT) {
+        if (in_array($this->getType(), [DocumentInterface::TYPE_OBJECT, DocumentInterface::TYPE_VARIANT], true)) {
             return $this->getSubType() . '\Listing';
         }
 
@@ -76,7 +76,7 @@ abstract class AbstractDocument implements DocumentInterface
 
     public function getPimcoreElement(ElasticaDocument $document): AbstractElement
     {
-        if ($this->getType() === DocumentInterface::TYPE_OBJECT || $this->getType() === DocumentInterface::TYPE_VARIANT) {
+        if (in_array($this->getType(), [DocumentInterface::TYPE_OBJECT, DocumentInterface::TYPE_VARIANT], true)) {
             $pimcoreId = $this->getPimcoreId($document);
             $element = Concrete::getById($pimcoreId);
 

--- a/src/DocumentType/AbstractDocument.php
+++ b/src/DocumentType/AbstractDocument.php
@@ -62,7 +62,7 @@ abstract class AbstractDocument implements DocumentInterface
 
     public function getListingClass(): string
     {
-        if ($this->getType() === DocumentInterface::TYPE_OBJECT) {
+        if ($this->getType() === DocumentInterface::TYPE_OBJECT || $this->getType() === DocumentInterface::TYPE_VARIANT) {
             return $this->getSubType() . '\Listing';
         }
 
@@ -76,7 +76,7 @@ abstract class AbstractDocument implements DocumentInterface
 
     public function getPimcoreElement(ElasticaDocument $document): AbstractElement
     {
-        if ($this->getType() === DocumentInterface::TYPE_OBJECT) {
+        if ($this->getType() === DocumentInterface::TYPE_OBJECT || $this->getType() === DocumentInterface::TYPE_VARIANT) {
             $pimcoreId = $this->getPimcoreId($document);
             $element = Concrete::getById($pimcoreId);
 

--- a/src/DocumentType/DocumentInterface.php
+++ b/src/DocumentType/DocumentInterface.php
@@ -30,7 +30,12 @@ interface DocumentInterface
      * Indicates the definition of a DataObject.
      */
     public const TYPE_OBJECT = 'object';
-    public const TYPES = [self::TYPE_ASSET, self::TYPE_DOCUMENT, self::TYPE_OBJECT];
+    /**
+     * For use in getType().
+     * Indicates the definition of a DataObject Variant.
+     */
+    public const TYPE_VARIANT = 'variant';
+    public const TYPES = [self::TYPE_ASSET, self::TYPE_DOCUMENT, self::TYPE_OBJECT, self::TYPE_VARIANT];
 
     /**
      * Defines the Pimcore type of this document. One of self::TYPES.

--- a/src/DocumentType/Index/IndexDocumentInterface.php
+++ b/src/DocumentType/Index/IndexDocumentInterface.php
@@ -93,4 +93,11 @@ interface IndexDocumentInterface extends DocumentInterface
      * @see ListingTrait
      */
     public function getListingInstance(IndexInterface $index): AbstractListing;
+
+    /**
+     * Whether object variants should be treated as separate entities i.e. Elasticsearch documents.
+     *
+     * @return bool
+     */
+    public function treatVariantsAsSeparateEntities(): bool;
 }

--- a/src/DocumentType/Index/IndexDocumentInterface.php
+++ b/src/DocumentType/Index/IndexDocumentInterface.php
@@ -95,9 +95,9 @@ interface IndexDocumentInterface extends DocumentInterface
     public function getListingInstance(IndexInterface $index): AbstractListing;
 
     /**
-     * Whether object variants should be treated as separate entities i.e. Elasticsearch documents.
+     * Whether Elasticsearch documents should be created for object variants.
      *
      * @return bool
      */
-    public function treatVariantsAsSeparateEntities(): bool;
+    public function treatObjectVariantsAsDocuments(): bool;
 }

--- a/src/DocumentType/Index/ListingTrait.php
+++ b/src/DocumentType/Index/ListingTrait.php
@@ -20,7 +20,7 @@ trait ListingTrait
 
     abstract public function getListingClass(): string;
 
-    abstract public function treatVariantsAsSeparateEntities(): bool;
+    abstract public function treatObjectVariantsAsDocuments(): bool;
 
     public function getIndexListingCondition(): ?string
     {
@@ -35,7 +35,7 @@ trait ListingTrait
         $listingInstance = new $listingClass();
         $listingInstance->setCondition($this->getIndexListingCondition());
 
-        if ($this->getType() === DocumentInterface::TYPE_OBJECT && $this->treatVariantsAsSeparateEntities()) {
+        if ($this->getType() === DocumentInterface::TYPE_OBJECT && $this->treatObjectVariantsAsDocuments()) {
             $listingInstance->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT]);
         }
 

--- a/src/DocumentType/Index/ListingTrait.php
+++ b/src/DocumentType/Index/ListingTrait.php
@@ -2,7 +2,7 @@
 
 namespace Valantic\ElasticaBridgeBundle\DocumentType\Index;
 
-use Pimcore\Model\DataObject\Listing;
+use Pimcore\Model\DataObject;
 use Pimcore\Model\Listing\AbstractListing;
 use Valantic\ElasticaBridgeBundle\DocumentType\DocumentInterface;
 use Valantic\ElasticaBridgeBundle\Index\IndexInterface;
@@ -20,6 +20,8 @@ trait ListingTrait
 
     abstract public function getListingClass(): string;
 
+    abstract public function treatVariantsAsSeparateEntities(): bool;
+
     public function getIndexListingCondition(): ?string
     {
         return null;
@@ -27,11 +29,15 @@ trait ListingTrait
 
     public function getListingInstance(IndexInterface $index): AbstractListing
     {
-        /** @var Listing $listingClass */
+        /** @var AbstractListing $listingClass */
         $listingClass = $this->getListingClass();
 
         $listingInstance = new $listingClass();
         $listingInstance->setCondition($this->getIndexListingCondition());
+
+        if ($this->getType() === DocumentInterface::TYPE_OBJECT && $this->treatVariantsAsSeparateEntities()) {
+            $listingInstance->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_VARIANT]);
+        }
 
         if ($this->getType() === DocumentInterface::TYPE_DOCUMENT) {
             $typeCondition = sprintf("`type` = '%s'", $this->getDocumentType());

--- a/src/DocumentType/Index/ListingTrait.php
+++ b/src/DocumentType/Index/ListingTrait.php
@@ -36,7 +36,7 @@ trait ListingTrait
         $listingInstance->setCondition($this->getIndexListingCondition());
 
         if ($this->getType() === DocumentInterface::TYPE_OBJECT && $this->treatVariantsAsSeparateEntities()) {
-            $listingInstance->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_VARIANT]);
+            $listingInstance->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT]);
         }
 
         if ($this->getType() === DocumentInterface::TYPE_DOCUMENT) {

--- a/src/EventListener/Pimcore/AbstractListener.php
+++ b/src/EventListener/Pimcore/AbstractListener.php
@@ -2,6 +2,7 @@
 
 namespace Valantic\ElasticaBridgeBundle\EventListener\Pimcore;
 
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\Element\AbstractElement;
 use Valantic\ElasticaBridgeBundle\DocumentType\Index\IndexDocumentInterface;
 use Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient;
@@ -51,6 +52,7 @@ abstract class AbstractListener
      * 1. Which indices might need to be updated?
      * 2. Does the element need to be in Elasticsearch or not?
      * 3. Are there Elasticsearch documents to be created/updated or deleted?
+     *
      * @param AbstractElement $element
      */
     protected function decideAction(AbstractElement $element): void
@@ -60,6 +62,10 @@ abstract class AbstractListener
 
             if (!$indexDocument || !in_array(get_class($indexDocument), $index->subscribedDocuments(), true)) {
                 continue;
+            }
+
+            if ($element->getType() === AbstractObject::OBJECT_TYPE_VARIANT && !$indexDocument->treatVariantsAsSeparateEntities()) {
+                $element = $element->getParent();
             }
 
             $elasticsearchId = $indexDocument->getElasticsearchId($element);

--- a/src/EventListener/Pimcore/AbstractListener.php
+++ b/src/EventListener/Pimcore/AbstractListener.php
@@ -64,8 +64,8 @@ abstract class AbstractListener
                 continue;
             }
 
-            if ($element->getType() === AbstractObject::OBJECT_TYPE_VARIANT && !$indexDocument->treatVariantsAsSeparateEntities()) {
-                $element = $element->getParent();
+            if ($element->getType() === AbstractObject::OBJECT_TYPE_VARIANT && !$indexDocument->treatObjectVariantsAsDocuments()) {
+                continue;
             }
 
             $elasticsearchId = $indexDocument->getElasticsearchId($element);

--- a/src/Index/AbstractIndex.php
+++ b/src/Index/AbstractIndex.php
@@ -126,6 +126,7 @@ abstract class AbstractIndex implements IndexInterface
 
             if (in_array($documentInstance->getType(), [
                     DocumentInterface::TYPE_OBJECT,
+                    DocumentInterface::TYPE_VARIANT,
                     DocumentInterface::TYPE_DOCUMENT,
                 ], true) && $documentInstance->getSubType() === get_class($element)) {
                 return $documentInstance;


### PR DESCRIPTION
Previously, when an object variant would be saved, the listener picked up on it and it resulted in an exception due to its unknown type.

This PR adds basic support for variants. Due to the new interface method, this is technically a breaking change.