### PR TITLE
Provide functionality to reset tenant

### DIFF
--- a/src/Command/Index.php
+++ b/src/Command/Index.php
@@ -221,6 +221,10 @@ class Index extends BaseCommand
             $this->output->writeln('');
 
             throw new IndexingFailedException($throwable);
+        } finally {
+            if (isset($indexDocumentInstance)) {
+                $this->documentHelper->setTenantIfNeeded($indexDocumentInstance, $indexConfig);
+            }
         }
 
         $progressBar->finish();

--- a/src/DocumentType/Index/TenantAwareInterface.php
+++ b/src/DocumentType/Index/TenantAwareInterface.php
@@ -26,4 +26,15 @@ interface TenantAwareInterface
      * @param string $tenant
      */
     public function setTenant(string $tenant): void;
+
+    /**
+     * Reset the active tenant.
+     * Useful for resetting the tenant after processing the index, especially in the context
+     * of the event listener in combination with Pimcore Sites.
+     *
+     * The implementation (together with setTenant())
+     * is responsible for keeping track of the "old" tenant (which may not be $this->activeTenant but e.g.
+     * the currently active Site).
+     */
+    public function resetTenant(): void;
 }

--- a/src/DocumentType/Index/TenantAwareTrait.php
+++ b/src/DocumentType/Index/TenantAwareTrait.php
@@ -28,4 +28,8 @@ trait TenantAwareTrait
     {
         $this->activeTenant = $tenant;
     }
+
+    public function resetTenant(): void
+    {
+    }
 }

--- a/src/DocumentType/Index/TenantAwareTrait.php
+++ b/src/DocumentType/Index/TenantAwareTrait.php
@@ -31,5 +31,6 @@ trait TenantAwareTrait
 
     public function resetTenant(): void
     {
+        // intentionally left blank
     }
 }

--- a/src/EventListener/Pimcore/AbstractListener.php
+++ b/src/EventListener/Pimcore/AbstractListener.php
@@ -68,10 +68,12 @@ abstract class AbstractListener
             $this->documentHelper->setTenantIfNeeded($indexDocument, $index);
 
             if (!in_array(get_class($indexDocument), $index->subscribedDocuments(), true)) {
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
             if ($element->getType() === AbstractObject::OBJECT_TYPE_VARIANT && !$indexDocument->treatObjectVariantsAsDocuments()) {
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
@@ -87,9 +89,12 @@ abstract class AbstractListener
                     $this->addElementToIndex($element, $index, $indexDocument);
                 }
             }
+
             if (!$indexDocument->shouldIndex($element) && $isPresent) {
                 $this->deleteElementFromIndex($element, $index, $indexDocument);
             }
+
+            $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
         }
     }
 
@@ -105,15 +110,18 @@ abstract class AbstractListener
             $this->documentHelper->setTenantIfNeeded($indexDocument, $index);
 
             if (!in_array(get_class($indexDocument), $index->subscribedDocuments(), true) || !$indexDocument->shouldIndex($element)) {
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
             if ($this->indexHelper->isIdInIndex($indexDocument->getElasticsearchId($element), $index)) {
                 $this->updateElementInIndex($element, $index, $indexDocument);
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
             $this->addElementToIndex($element, $index, $indexDocument);
+            $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
         }
     }
 
@@ -129,16 +137,19 @@ abstract class AbstractListener
             $this->documentHelper->setTenantIfNeeded($indexDocument, $index);
 
             if (!in_array(get_class($indexDocument), $index->subscribedDocuments(), true)) {
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
             $elasticsearchId = $indexDocument->getElasticsearchId($element);
 
             if (!$this->indexHelper->isIdInIndex($elasticsearchId, $index)) {
+                $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
                 continue;
             }
 
             $index->getElasticaIndex()->deleteById($elasticsearchId);
+            $this->documentHelper->resetTenantIfNeeded($indexDocument, $index);
         }
     }
 

--- a/src/Index/TenantAwareInterface.php
+++ b/src/Index/TenantAwareInterface.php
@@ -37,6 +37,17 @@ interface TenantAwareInterface
     public function setTenant(string $tenant): void;
 
     /**
+     * Reset the active tenant.
+     * Useful for resetting the tenant after processing the index, especially in the context
+     * of the event listener in combination with Pimcore Sites.
+     *
+     * The implementation (together with setTenant())
+     * is responsible for keeping track of the "old" tenant (which may not be $this->activeTenant but e.g.
+     * the currently active Site).
+     */
+    public function resetTenant(): void;
+
+    /**
      * Used instead of getName(). In a tenant context, getName() includes the tenant name and corresponds to the
      * name of the tenant in Elasticsearch. This method creates the base name for the tenant-specific name.
      *

--- a/src/Index/TenantAwareTrait.php
+++ b/src/Index/TenantAwareTrait.php
@@ -40,5 +40,6 @@ trait TenantAwareTrait
 
     public function resetTenant(): void
     {
+        // intentionally left blank
     }
 }

--- a/src/Index/TenantAwareTrait.php
+++ b/src/Index/TenantAwareTrait.php
@@ -37,4 +37,8 @@ trait TenantAwareTrait
     {
         return sprintf('%s_%s', $this->getTenantUnawareName(), $this->getTenant());
     }
+
+    public function resetTenant(): void
+    {
+    }
 }

--- a/src/Service/DocumentHelper.php
+++ b/src/Service/DocumentHelper.php
@@ -47,4 +47,17 @@ class DocumentHelper
             $indexDocument->setTenant($index->getTenant());
         }
     }
+
+    /**
+     * Reset the tenant (if needed) on the IndexDocument based on the Index tenant.
+     *
+     * @param IndexDocumentInterface $indexDocument
+     * @param IndexInterface $index
+     */
+    public function resetTenantIfNeeded(IndexDocumentInterface $indexDocument, IndexInterface $index): void
+    {
+        if ($index instanceof IndexTenantAwareInterfaceAlias && $indexDocument instanceof IndexDocumentTenantAwareInterface) {
+            $indexDocument->resetTenant();
+        }
+    }
 }


### PR DESCRIPTION
Due to how `\Valantic\ElasticaBridgeBundle\Repository\IndexRepository::flattened` works and depending on the implementation of `\Valantic\ElasticaBridgeBundle\Index\TenantAwareInterface::setTenant` and `\Valantic\ElasticaBridgeBundle\DocumentType\Index\TenantAwareInterface::setTenant` we might change the system in unintended ways (e.g. when Pimcore Sites are used, the system might run in a different Site context after `\Valantic\ElasticaBridgeBundle\EventListener\Pimcore\AbstractListener::decideAction` has finished).

This PR adds an extension point to reset the tenant to both affected interfaces.