### PR TITLE
[BUGFIX] Fixed bug which prevents document from indexing when using multiple tenants

### DIFF
--- a/src/Repository/IndexRepository.php
+++ b/src/Repository/IndexRepository.php
@@ -46,6 +46,7 @@ class IndexRepository
         foreach ($this->all() as $indexConfig) {
             if ($indexConfig instanceof TenantAwareInterface) {
                 foreach ($indexConfig->getTenants() as $tenant) {
+                    $indexConfig = clone $indexConfig;
                     $indexConfig->setTenant($tenant);
                     yield $indexConfig->getName() => $indexConfig;
                 }


### PR DESCRIPTION
While the index command works for multiple tenants, no action is triggered when an object is saved in pimcore.
This fixes this behaviour by creating a new config for each tenant.