### PR TITLE
Improve setup in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ This package is developed by [valantic CEC Schweiz](https://www.valantic.com/en/
 ## Setup
 
 1. `composer require valantic/pimcore-elastica-bridge`
-1. Use the Pimcore UI
-    1. Open the Tools -> Bundles screen in Pimcore
-    1. Enable the bundle
-1. Use the Pimcore CLI
-    1. `console pimcore:bundle:enable ValanticElasticaBridgeBundle`
-1. If all else fails
-    1. Edit `var/config/extensions.php`
-    1. Add `"Valantic\\ElasticaBridgeBundle\\ValanticElasticaBridgeBundle" => TRUE,`
+1. Enable the bundle using one of the following methods
+    - Use the Pimcore UI
+        1. Open the Tools -> Bundles screen in Pimcore
+        1. Enable the bundle
+    - Use the Pimcore CLI
+        1. `bin/console pimcore:bundle:enable ValanticElasticaBridgeBundle`
+    - Edit files
+        1. Edit `var/config/extensions.php`
+        1. Add `"Valantic\\ElasticaBridgeBundle\\ValanticElasticaBridgeBundle" => TRUE,`
 1. Configure the connection to your Elasticsearch cluster as seen in [`example/app/config/config.yml`](example/app/config/config.yml)
 1. Don't forget to register your newly created services (implementing `IndexInterface` etc.) in your `services.yml`
    ```yml


### PR DESCRIPTION
The setup reads as if all of these steps have to be executed, but actually only one option should be chosen. I've rephrased to make this more clear.