### PR TITLE
Fix indexing of assets

### DIFF
--- a/src/DocumentType/AbstractDocument.php
+++ b/src/DocumentType/AbstractDocument.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Valantic\ElasticaBridgeBundle\DocumentType;
 
 use Elastica\Document as ElasticaDocument;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document as PimcoreDocument;
 use Pimcore\Model\Document\Listing as DocumentListing;
@@ -46,6 +47,10 @@ abstract class AbstractDocument implements DocumentInterface
             return $element->getType() . $element->getId();
         }
 
+        if ($element instanceof Asset) {
+            return DocumentInterface::TYPE_ASSET . $element->getId();
+        }
+
         if ($element instanceof PimcoreDocument) {
             return DocumentInterface::TYPE_DOCUMENT . $element->getId();
         }
@@ -65,6 +70,10 @@ abstract class AbstractDocument implements DocumentInterface
     public function getListingClass(): string
     {
         if (in_array($this->getType(), [DocumentInterface::TYPE_OBJECT, DocumentInterface::TYPE_VARIANT], true)) {
+            return $this->getSubType() . '\Listing';
+        }
+
+        if (in_array($this->getType(), [DocumentInterface::TYPE_ASSET], true)) {
             return $this->getSubType() . '\Listing';
         }
 

--- a/src/DocumentType/Index/ListingTrait.php
+++ b/src/DocumentType/Index/ListingTrait.php
@@ -51,7 +51,7 @@ trait ListingTrait
             $listingInstance->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT]);
         }
 
-        if ($this->getType() === DocumentInterface::TYPE_DOCUMENT) {
+        if (in_array($this->getType(), [DocumentInterface::TYPE_DOCUMENT, DocumentInterface::TYPE_ASSET], true)) {
             $typeCondition = sprintf("`type` = '%s'", $this->getDocumentType());
             if ($this->getIndexListingCondition() !== null) {
                 $listingInstance->setCondition(sprintf('%s AND (%s)', $typeCondition, $this->getIndexListingCondition()));


### PR DESCRIPTION
There was already a `TYPE_ASSETS` constants availabe on the `DocumentInterface`, but when using it errors were thrown. With these changes it should be possible to index assets as well.