### PR TITLE
Add support for Pimcore 11 and Elasticsearch 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,9 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: ['8.1']
-        pimcore: ['^10.0']
-        stability: [prefer-lowest, prefer-stable]
+        php: [ '8.1', '8.2' ]
+        pimcore: [ '^11.0' ]
+        stability: [ prefer-lowest, prefer-stable ]
+        elastica: [ '^7.1', '8.x-dev' ]
 
     steps:
       - name: Checkout code
@@ -33,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "pimcore/pimcore:${{ matrix.pimcore }}" --no-interaction --no-update
+          composer require "pimcore/pimcore:${{ matrix.pimcore }}" "ruflin/elastica:${{ matrix.elastica }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List installed dependencies

--- a/README.md
+++ b/README.md
@@ -13,15 +13,7 @@ The only job of the bundle is to store Pimcore elements (assets, documents, data
 ## Setup
 
 1. `composer require valantic/pimcore-elastica-bridge`
-1. Enable the bundle using one of the following methods
-    - Use the Pimcore UI
-        1. Open the Tools -> Bundles screen in Pimcore
-        1. Enable the bundle
-    - Use the Pimcore CLI
-        1. `bin/console pimcore:bundle:enable ValanticElasticaBridgeBundle`
-    - Edit files
-        1. Edit `var/config/extensions.php`
-        1. Add `"Valantic\\ElasticaBridgeBundle\\ValanticElasticaBridgeBundle" => TRUE,`
+1. Edit `config/bundles.php` and add `\Valantic\ElasticaBridgeBundle\ValanticElasticaBridgeBundle::class => ['all' => true],`
 1. Configure the connection to your Elasticsearch cluster as seen in [`example/app/config/config.yml`](example/app/config/config.yml)
 1. Don't forget to register your newly created services (implementing `IndexInterface` etc.) in your `services.yml`
    ```yml

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
   "require": {
     "php": "^8.1",
     "ext-json": "*",
-    "pimcore/pimcore": "^10.0",
-    "psr/log": "^1.0",
-    "ruflin/elastica": "^7.1",
-    "symfony/console": "^5.4"
+    "pimcore/pimcore": "^11.0",
+    "psr/log": "^3.0",
+    "ruflin/elastica": "^7.1 || 8.x-dev",
+    "symfony/console": "^6.2"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.8.2",
@@ -19,7 +19,8 @@
     "phpstan/phpstan-strict-rules": "^1.5.1",
     "rector/rector": "^0.17.6",
     "roave/security-advisories": "dev-latest",
-    "sentry/sentry": "^3.20.1"
+    "sentry/sentry": "^3.20.1",
+    "symfony/http-client": "^6.2"
   },
   "license": "MIT",
   "authors": [

--- a/src/Command/Cleanup.php
+++ b/src/Command/Cleanup.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Valantic\ElasticaBridgeBundle\Command;
 
 use Elastica\Exception\ResponseException;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,10 +43,11 @@ class Cleanup extends BaseCommand
                 ? 'Deleting ALL indices in the cluster'
                 : 'Only deleting KNOWN indices'
         );
+        /** @var QuestionHelper $helper */
         $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion('Are you sure you want to proceed deleting indices and aliases? (y/N)', false);
 
-        if (!$helper->ask($input, $output, $question)) {
+        if ($helper->ask($input, $output, $question) === false) {
             return self::FAILURE;
         }
 

--- a/src/Command/PopulateIndex.php
+++ b/src/Command/PopulateIndex.php
@@ -91,7 +91,7 @@ class PopulateIndex extends BaseCommand
                     $listing->setOffset($batchNumber * $indexConfig->getBatchSize());
                     $listing->setLimit($indexConfig->getBatchSize());
 
-                    foreach ($listing->getData() as $dataObject) {
+                    foreach ($listing->getData() ?? [] as $dataObject) {
                         $progressBar->advance();
 
                         if (!$documentInstance->shouldIndex($dataObject)) {

--- a/src/Document/AbstractDocument.php
+++ b/src/Document/AbstractDocument.php
@@ -171,6 +171,23 @@ abstract class AbstractDocument implements DocumentInterface
      */
     protected function getTypeMappingForDocuments(): array
     {
+        $possibleBundleTypes = [
+            '\Pimcore\Model\DocumentNewsletter' => 'newsletter',
+            '\Pimcore\Model\DocumentPrintpage' => 'printpage',
+            '\Pimcore\Model\DocumentPrintcontainer' => 'printcontainer',
+        ];
+
+        /** @var array<class-string,string> $availableBundleTypes */
+        $availableBundleTypes = [];
+
+        foreach ($possibleBundleTypes as $className => $mapped) {
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $availableBundleTypes[$className] = $mapped;
+        }
+
         return [
             PimcoreDocument\Folder::class => 'folder',
             PimcoreDocument\Page::class => 'page',
@@ -178,9 +195,7 @@ abstract class AbstractDocument implements DocumentInterface
             PimcoreDocument\Link::class => 'link',
             PimcoreDocument\Hardlink::class => 'hardlink',
             PimcoreDocument\Email::class => 'email',
-            PimcoreDocument\Newsletter::class => 'newsletter',
-            PimcoreDocument\Printpage::class => 'printpage',
-            PimcoreDocument\Printcontainer::class => 'printcontainer',
+            ...$availableBundleTypes,
         ];
     }
 

--- a/src/Logger/SentryBreadcrumbLogger.php
+++ b/src/Logger/SentryBreadcrumbLogger.php
@@ -16,8 +16,12 @@ class SentryBreadcrumbLogger implements LoggerInterface
     /**
      * @param LogLevel::*|mixed $level
      */
-    public function log($level, $message, array $context = []): void
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
+        if ($message instanceof \Stringable) {
+            $message = $message->__toString();
+        }
+
         \Sentry\addBreadcrumb(
             new Breadcrumb(
                 match ($level) {


### PR DESCRIPTION
Issues:
- Since `ruflin/elastica` [has no `8.x` tag yet](https://github.com/ruflin/Elastica/releases), we're requiring `8.x-dev`
- Since https://github.com/ruflin/Elastica/pull/2168 has not yet been merged, `elasticsearch/elasticsearch` is still required as `^7.10`