### PR TITLE
Index locks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "pimcore/pimcore": "^11.0",
     "psr/log": "^3.0",
     "ruflin/elastica": "^7.1 || 8.x-dev",
-    "symfony/console": "^6.2"
+    "symfony/console": "^6.2",
+    "symfony/lock": "^6.2"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -112,8 +112,8 @@ class Status extends BaseCommand
         $activeBlueGreen = 'N/A';
 
         if ($exists) {
-            $stats = $indexConfig->getElasticaIndex()->getStats()->get()['indices'];
-            $stats = array_values($stats)[0]['total'];
+            $stats = $indexConfig->getElasticaIndex()->getStats()->get('indices');
+            $stats = array_values($stats)[0]['primaries'];
             $numDocs = $stats['docs']['count'];
             $size = $stats['store']['size_in_bytes'];
         }
@@ -149,7 +149,7 @@ class Status extends BaseCommand
         $index = $this->esClient->getIndex($indexName);
 
         $stats = $index->getStats()->get()['indices'];
-        $stats = array_values($stats)[0]['total'];
+        $stats = array_values($stats)[0]['primaries'];
         $numDocs = $stats['docs']['count'];
         $size = $stats['store']['size_in_bytes'];
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,8 +24,9 @@ class Configuration implements ConfigurationInterface
             ->children()
             ->arrayNode('client')
             ->children()
-            ->scalarNode('host')->defaultValue('localhost')->end()
-            ->integerNode('port')->defaultValue(9200)->end()
+            ->scalarNode('host')->defaultValue('localhost')->setDeprecated('valantic/pimcore-elastica-bridge', '3.1.0', 'Use the "dsn" option instead, e.g. http://username:password@localhost:9200/')->end()
+            ->integerNode('port')->defaultValue(9200)->setDeprecated('valantic/pimcore-elastica-bridge', '3.1.0', 'Use the "dsn" option instead, e.g. http://username:password@localhost:9200/')->end()
+            ->scalarNode('dsn')->defaultNull()->end()
             ->booleanNode('addSentryBreadcrumbs')->defaultValue(false)->end()
             ->end()
             ->end();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,14 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('dsn')->defaultNull()->end()
             ->booleanNode('addSentryBreadcrumbs')->defaultValue(false)->end()
             ->end()
+            ->end()
+            ->arrayNode('indexing')
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->integerNode('lock_timeout')->defaultValue(5 * 60)->info('To prevent overlapping indexing jobs. Set to a value higher than the slowest index. Value is specified in seconds.')->end()
+            ->end()
+            ->end()
+            ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/ValanticElasticaBridgeExtension.php
+++ b/src/DependencyInjection/ValanticElasticaBridgeExtension.php
@@ -39,10 +39,6 @@ class ValanticElasticaBridgeExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
 
-        $clientConfig = $config['client'];
-        array_walk(
-            $clientConfig,
-            fn ($value, $key) => $container->setParameter('valantic_elastica_bridge.client.' . $key, $value)
-        );
+        $container->setParameter('valantic_elastica_bridge', $config);
     }
 }

--- a/src/Elastica/Client/ElasticsearchClientFactory.php
+++ b/src/Elastica/Client/ElasticsearchClientFactory.php
@@ -11,12 +11,17 @@ class ElasticsearchClientFactory
     public static function createElasticsearchClient(
         string $host,
         int $port,
+        ?string $dsn,
         bool $addSentryBreadcrumbs,
     ): ElasticsearchClient {
-        $esClient = new ElasticsearchClient([
-            'host' => $host,
-            'port' => $port,
-        ]);
+        $config = $dsn !== null && $dsn !== ''
+            ? $dsn
+            : [
+                'host' => $host,
+                'port' => $port,
+            ];
+
+        $esClient = new ElasticsearchClient($config);
 
         if ($addSentryBreadcrumbs && class_exists('\Sentry\Breadcrumb')) {
             $esClient->setLogger(new SentryBreadcrumbLogger());

--- a/src/Elastica/Client/ElasticsearchClientFactory.php
+++ b/src/Elastica/Client/ElasticsearchClientFactory.php
@@ -5,25 +5,19 @@ declare(strict_types=1);
 namespace Valantic\ElasticaBridgeBundle\Elastica\Client;
 
 use Valantic\ElasticaBridgeBundle\Logger\SentryBreadcrumbLogger;
+use Valantic\ElasticaBridgeBundle\Repository\ConfigurationRepository;
 
 class ElasticsearchClientFactory
 {
-    public static function createElasticsearchClient(
-        string $host,
-        int $port,
-        ?string $dsn,
-        bool $addSentryBreadcrumbs,
+    public function __construct(
+        private readonly ConfigurationRepository $configurationRepository,
+    ) {}
+
+    public function __invoke(
     ): ElasticsearchClient {
-        $config = $dsn !== null && $dsn !== ''
-            ? $dsn
-            : [
-                'host' => $host,
-                'port' => $port,
-            ];
+        $esClient = new ElasticsearchClient($this->configurationRepository->getClient());
 
-        $esClient = new ElasticsearchClient($config);
-
-        if ($addSentryBreadcrumbs && class_exists('\Sentry\Breadcrumb')) {
+        if ($this->configurationRepository->getAddSentryBreadcrumbs() && class_exists('\Sentry\Breadcrumb')) {
             $esClient->setLogger(new SentryBreadcrumbLogger());
         }
 

--- a/src/Repository/ConfigurationRepository.php
+++ b/src/Repository/ConfigurationRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valantic\ElasticaBridgeBundle\Repository;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+
+class ConfigurationRepository
+{
+    public function __construct(
+        private readonly ContainerBagInterface $containerBag,
+    ) {}
+
+    /**
+     * @return array{host:string,port:int}|string
+     */
+    public function getClient(): array|string
+    {
+        $config = $this->containerBag->get('valantic_elastica_bridge')['client'];
+
+        return $config['dsn'] !== null && $config['dsn'] !== ''
+              ? $config['dsn']
+              : [
+                  'host' => $config['host'],
+                  'port' => $config['port'],
+              ];
+    }
+
+    public function getAddSentryBreadcrumbs(): bool
+    {
+        return $this->containerBag->get('valantic_elastica_bridge')['client']['addSentryBreadcrumbs'];
+    }
+
+    public function getIndexingLockTimeout(): int
+    {
+        return $this->containerBag->get('valantic_elastica_bridge')['indexing']['lock_timeout'];
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
     arguments:
       $host: '%valantic_elastica_bridge.client.host%'
       $port: '%valantic_elastica_bridge.client.port%'
+      $dsn: '%valantic_elastica_bridge.client.dsn%'
       $addSentryBreadcrumbs: '%valantic_elastica_bridge.client.addSentryBreadcrumbs%'
 
   Valantic\ElasticaBridgeBundle\Service\:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,19 +8,18 @@ services:
     resource: '../../Command/*'
     tags: [ 'console.command' ]
 
+  Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClientFactory: ~
+
   Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient:
-    factory: [ 'Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClientFactory', 'createElasticsearchClient' ]
-    arguments:
-      $host: '%valantic_elastica_bridge.client.host%'
-      $port: '%valantic_elastica_bridge.client.port%'
-      $dsn: '%valantic_elastica_bridge.client.dsn%'
-      $addSentryBreadcrumbs: '%valantic_elastica_bridge.client.addSentryBreadcrumbs%'
+    factory: '@Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClientFactory'
 
   Valantic\ElasticaBridgeBundle\Service\:
     resource: '../../Service/*'
 
   Valantic\ElasticaBridgeBundle\EventListener\:
     resource: '../../EventListener/*'
+
+  Valantic\ElasticaBridgeBundle\Repository\ConfigurationRepository:
 
   Valantic\ElasticaBridgeBundle\Repository\IndexRepository:
     arguments:


### PR DESCRIPTION
- deprecate host and port in favor of DSN connection strings
- resolve #48 
- use configuration repository
- prevent overlapping index jobs by using locks