### PR TITLE
Pimcore 11 fix: prevent variants from being present in object listings

### DIFF
--- a/src/Document/AbstractDocument.php
+++ b/src/Document/AbstractDocument.php
@@ -46,12 +46,20 @@ abstract class AbstractDocument implements DocumentInterface
             $listingInstance->setUnpublished($this->includeUnpublishedElementsInListing());
         }
 
-        if ($this->getType() === DocumentType::DATA_OBJECT && $this->treatObjectVariantsAsDocuments()) {
+        if ($this->getType() === DocumentType::DATA_OBJECT) {
             /** @var DataObjectListing $listingInstance */
-            $listingInstance->setObjectTypes([
-                DataObject\AbstractObject::OBJECT_TYPE_OBJECT,
-                DataObject\AbstractObject::OBJECT_TYPE_VARIANT,
-            ]);
+            if ($this->treatObjectVariantsAsDocuments()) {
+                $listingInstance->setObjectTypes([
+                    DataObject\AbstractObject::OBJECT_TYPE_OBJECT,
+                    DataObject\AbstractObject::OBJECT_TYPE_VARIANT,
+                ]);
+            }
+
+            if (!$this->treatObjectVariantsAsDocuments()) {
+                $listingInstance->setObjectTypes([
+                    DataObject\AbstractObject::OBJECT_TYPE_OBJECT,
+                ]);
+            }
         }
 
         if ($this->getSubType() !== null && in_array($this->getType(), DocumentType::casesSubTypeListing(), true)) {


### PR DESCRIPTION
From [the upgrade notes](https://pimcore.com/docs/platform/Pimcore/Installation_and_Upgrade/Upgrade_Notes/#data-objects-1)

> Changed $objectTypes default value to include variants in certain scenarios.


This wasn't caught before and needs fixing.