### PR TITLE
Housekeeping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "ext-json": "*",
     "pimcore/pimcore": "^11.0",
     "psr/log": "^3.0",
-    "ruflin/elastica": "8.x-dev",
+    "ruflin/elastica": "8.x-dev#78d5a9e",
     "symfony/console": "^6.2",
     "symfony/lock": "^6.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.8.2",
     "phpstan/extension-installer": "^1.3.1",
-    "phpstan/phpstan": "^1.10.62",
+    "phpstan/phpstan": "^1.10.63",
     "phpstan/phpstan-deprecation-rules": "^1.1.4",
     "phpstan/phpstan-strict-rules": "^1.5.2",
-    "rector/rector": "^1.0.2",
+    "rector/rector": "^1.0.3",
     "roave/security-advisories": "dev-latest",
     "sentry/sentry": "^3.22.1",
     "symfony/http-client": "^6.4.5"

--- a/src/Elastica/Client/ElasticsearchClientFactory.php
+++ b/src/Elastica/Client/ElasticsearchClientFactory.php
@@ -15,12 +15,15 @@ class ElasticsearchClientFactory
 
     public function __invoke(
     ): ElasticsearchClient {
-        $esClient = new ElasticsearchClient($this->configurationRepository->getClientDsn());
+        $logger = null;
 
         if ($this->configurationRepository->shouldAddSentryBreadcrumbs() && class_exists('\Sentry\Breadcrumb')) {
-            $esClient->setLogger(new SentryBreadcrumbLogger());
+            $logger = (new SentryBreadcrumbLogger());
         }
 
-        return $esClient;
+        return new ElasticsearchClient(
+            $this->configurationRepository->getClientDsn(),
+            logger: $logger
+        );
     }
 }

--- a/vendor-bin/phpcs/composer.json
+++ b/vendor-bin/phpcs/composer.json
@@ -1,5 +1,5 @@
 {
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.51.0"
+        "friendsofphp/php-cs-fixer": "^3.52.0"
     }
 }

--- a/vendor-bin/phpcs/composer.lock
+++ b/vendor-bin/phpcs/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3dc63bf9649475685580f575fe9a267a",
+    "content-hash": "c99066bc80fd0b271ea606fff793760b",
     "packages": [],
     "packages-dev": [
         {
             "name": "composer/pcre",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace"
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4775f35b2d70865807c89d32c8e7385b86eb0ace",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.3"
             },
             "funding": [
                 {
@@ -76,7 +76,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-07T15:38:35+00:00"
+            "time": "2024-03-19T10:26:25+00:00"
         },
         {
             "name": "composer/semver",
@@ -227,16 +227,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.51.0",
+            "version": "v3.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd"
+                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/127fa74f010da99053e3f5b62672615b72dd6efd",
-                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
+                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
                 "shasum": ""
             },
             "require": {
@@ -307,7 +307,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.51.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.52.0"
             },
             "funding": [
                 {
@@ -315,7 +315,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-28T19:50:06+00:00"
+            "time": "2024-03-18T18:40:11+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
This locks `ruflin/elastica` as there are breaking changes on `8.x-dev`. https://github.com/ruflin/Elastica/compare/8bcb02d..78d5a9e should be handled.