### PR TITLE
Implemented subprocesses for indexing huge indices

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -8,5 +8,16 @@ use Pimcore\Console\AbstractCommand;
 
 abstract class BaseCommand extends AbstractCommand
 {
-    protected const COMMAND_NAMESPACE = 'valantic:elastica-bridge:';
+    protected function displayThrowable(\Throwable $throwable): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln(sprintf('In %s line %d', $throwable->getFile(), $throwable->getLine()));
+        $this->output->writeln('');
+
+        $this->output->writeln($throwable->getMessage());
+        $this->output->writeln('');
+
+        $this->output->writeln($throwable->getTraceAsString());
+        $this->output->writeln('');
+    }
 }

--- a/src/Command/Cleanup.php
+++ b/src/Command/Cleanup.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Valantic\ElasticaBridgeBundle\Constant\CommandConstants;
 use Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient;
 use Valantic\ElasticaBridgeBundle\Repository\IndexRepository;
 
@@ -27,7 +28,7 @@ class Cleanup extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName(self::COMMAND_NAMESPACE . 'cleanup')
+        $this->setName(CommandConstants::COMMAND_CLEANUP)
             ->setDescription('Deletes Elasticsearch indices and aliases known to (i.e. created by) the bundle')
             ->addOption(
                 self::OPTION_ALL_IN_CLUSTER,

--- a/src/Command/DoPopulateIndex.php
+++ b/src/Command/DoPopulateIndex.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valantic\ElasticaBridgeBundle\Command;
+
+use Elastica\Index as ElasticaIndex;
+use Pimcore\Model\Element\AbstractElement;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Valantic\ElasticaBridgeBundle\Constant\CommandConstants;
+use Valantic\ElasticaBridgeBundle\Exception\Command\DocumentFailedException;
+use Valantic\ElasticaBridgeBundle\Index\IndexInterface;
+use Valantic\ElasticaBridgeBundle\Repository\ConfigurationRepository;
+use Valantic\ElasticaBridgeBundle\Repository\DocumentRepository;
+use Valantic\ElasticaBridgeBundle\Repository\IndexRepository;
+use Valantic\ElasticaBridgeBundle\Service\DocumentHelper;
+
+class DoPopulateIndex extends BaseCommand
+{
+    public function __construct(
+        private readonly IndexRepository $indexRepository,
+        private readonly DocumentRepository $documentRepository,
+        private readonly DocumentHelper $documentHelper,
+        private readonly ConfigurationRepository $configurationRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandConstants::COMMAND_DO_POPULATE_INDEX)
+            ->setHidden(true)
+            ->setDescription('[INTERNAL]')
+            ->addOption(CommandConstants::OPTION_CONFIG, mode: InputOption::VALUE_REQUIRED)
+            ->addOption(CommandConstants::OPTION_INDEX, mode: InputOption::VALUE_REQUIRED)
+            ->addOption(CommandConstants::OPTION_BATCH_NUMBER, mode: InputOption::VALUE_REQUIRED)
+            ->addOption(CommandConstants::OPTION_LISTING_COUNT, mode: InputOption::VALUE_REQUIRED)
+            ->addOption(CommandConstants::OPTION_DOCUMENT, mode: InputOption::VALUE_REQUIRED)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexConfig = $this->getIndex();
+
+        if (!$indexConfig instanceof IndexInterface) {
+            return self::FAILURE;
+        }
+
+        return $this->populateIndex($indexConfig, $indexConfig->getBlueGreenInactiveElasticaIndex());
+    }
+
+    private function getIndex(): ?IndexInterface
+    {
+        foreach ($this->indexRepository->flattenedAll() as $indexConfig) {
+            if ($indexConfig->getName() === $this->input->getOption(CommandConstants::OPTION_CONFIG)) {
+                return $indexConfig;
+            }
+        }
+
+        return null;
+    }
+
+    private function populateIndex(IndexInterface $indexConfig, ElasticaIndex $esIndex): int
+    {
+        ProgressBar::setFormatDefinition('custom', "%percent%%\t%remaining%\t%memory%\n%message%");
+
+        $batchNumber = (int) $this->input->getOption(CommandConstants::OPTION_BATCH_NUMBER);
+        $listingCount = (int) $this->input->getOption(CommandConstants::OPTION_LISTING_COUNT);
+
+        $allowedDocuments = $indexConfig->getAllowedDocuments();
+        $document = $this->input->getOption(CommandConstants::OPTION_DOCUMENT);
+
+        if (!in_array($document, $allowedDocuments, true)) {
+            return self::FAILURE;
+        }
+
+        $progressBar = new ProgressBar($this->output, $listingCount > 0 ? $listingCount : 1);
+        $progressBar->setMessage($document);
+        $progressBar->setFormat('custom');
+        $progressBar->setProgress($batchNumber * $indexConfig->getBatchSize());
+
+        if (!$indexConfig->shouldPopulateInSubprocesses()) {
+            $numberOfBatches = ceil($listingCount / $indexConfig->getBatchSize());
+
+            for ($batch = 0; $batch < $numberOfBatches; $batch++) {
+                $exitCode = $this->doPopulateIndex($esIndex, $indexConfig, $progressBar, $document, $batch);
+
+                if ($exitCode !== self::SUCCESS) {
+                    return $exitCode;
+                }
+            }
+        } else {
+            return $this->doPopulateIndex($esIndex, $indexConfig, $progressBar, $document, $batchNumber);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function doPopulateIndex(
+        ElasticaIndex $esIndex,
+        IndexInterface $indexConfig,
+        ProgressBar $progressBar,
+        string $document,
+        int $batchNumber,
+    ): int {
+        $documentInstance = $this->documentRepository->get($document);
+
+        $this->documentHelper->setTenantIfNeeded($documentInstance, $indexConfig);
+
+        $batchSize = $indexConfig->getBatchSize();
+
+        $listing = $documentInstance->getListingInstance($indexConfig);
+        $listing->setOffset($batchNumber * $batchSize);
+        $listing->setLimit($batchSize);
+
+        $esDocuments = [];
+
+        foreach ($listing->getData() ?? [] as $dataObject) {
+            try {
+                if (!$documentInstance->shouldIndex($dataObject)) {
+                    continue;
+                }
+                $progressBar->advance();
+
+                $esDocuments[] = $this->documentHelper->elementToDocument($documentInstance, $dataObject);
+            } catch (\Throwable $throwable) {
+                $this->displayDocumentError($indexConfig, $document, $dataObject, $throwable);
+
+                if (!$this->configurationRepository->shouldSkipFailingDocuments()) {
+                    throw new DocumentFailedException($throwable);
+                }
+            }
+        }
+
+        if (count($esDocuments) > 0) {
+            $esIndex->addDocuments($esDocuments);
+            $esDocuments = [];
+        }
+
+        if ($indexConfig->refreshIndexAfterEveryDocumentWhenPopulating()) {
+            $esIndex->refresh();
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function displayDocumentError(
+        IndexInterface $indexConfig,
+        string $document,
+        AbstractElement $dataObject,
+        \Throwable $throwable,
+    ): void {
+        $this->output->writeln('');
+        $this->output->writeln(sprintf(
+            '<fg=red;options=bold>Error while populating index %s, processing documents of type %s, last processed element ID %s.</>',
+            $indexConfig::class,
+            $document,
+            $dataObject->getId()
+        ));
+        $this->displayThrowable($throwable);
+    }
+}

--- a/src/Command/Index.php
+++ b/src/Command/Index.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Process\Process;
+use Valantic\ElasticaBridgeBundle\Constant\CommandConstants;
 use Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient;
 use Valantic\ElasticaBridgeBundle\Enum\IndexBlueGreenSuffix;
 use Valantic\ElasticaBridgeBundle\Exception\Index\BlueGreenIndicesIncorrectlySetupException;
@@ -39,7 +40,7 @@ class Index extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName(self::COMMAND_NAMESPACE . 'index')
+        $this->setName(CommandConstants::COMMAND_INDEX)
             ->setDescription('Ensures all the indices are present and populated.')
             ->addArgument(
                 self::ARGUMENT_INDEX,
@@ -169,9 +170,9 @@ class Index extends BaseCommand
         self::$isPopulating = true;
         $process = new Process(
             [
-                'bin/console', self::COMMAND_NAMESPACE . 'populate-index',
-                '--config', $indexConfig->getName(),
-                '--index', $esIndex->getName(),
+                'bin/console', CommandConstants::COMMAND_POPULATE_INDEX,
+                '--' . CommandConstants::OPTION_CONFIG, $indexConfig->getName(),
+                '--' . CommandConstants::OPTION_INDEX, $esIndex->getName(),
                 ...array_filter([$this->output->isVerbose() ? '-v' : null,
                     $this->output->isVeryVerbose() ? '-vv' : null,
                     $this->output->isDebug() ? '-vvv' : null,

--- a/src/Command/Refresh.php
+++ b/src/Command/Refresh.php
@@ -10,6 +10,7 @@ use Pimcore\Model\Document;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Valantic\ElasticaBridgeBundle\Constant\CommandConstants;
 use Valantic\ElasticaBridgeBundle\Service\PropagateChanges;
 
 class Refresh extends BaseCommand
@@ -26,7 +27,7 @@ class Refresh extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName(self::COMMAND_NAMESPACE . 'refresh')
+        $this->setName(CommandConstants::COMMAND_REFRESH)
             ->setDescription('Refresh one or more Elasticsearch documents')
             ->addOption(
                 self::OPTION_ASSETS,

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -7,6 +7,7 @@ namespace Valantic\ElasticaBridgeBundle\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Valantic\ElasticaBridgeBundle\Constant\CommandConstants;
 use Valantic\ElasticaBridgeBundle\Elastica\Client\ElasticsearchClient;
 use Valantic\ElasticaBridgeBundle\Exception\Index\BlueGreenIndicesIncorrectlySetupException;
 use Valantic\ElasticaBridgeBundle\Index\IndexInterface;
@@ -37,7 +38,7 @@ class Status extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName(self::COMMAND_NAMESPACE . 'status')
+        $this->setName(CommandConstants::COMMAND_STATUS)
             ->setDescription('Displays the status of the configured Elasticsearch indices');
     }
 

--- a/src/Constant/CommandConstants.php
+++ b/src/Constant/CommandConstants.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valantic\ElasticaBridgeBundle\Constant;
+
+interface CommandConstants
+{
+    public const OPTION_CONFIG = 'config';
+    public const OPTION_INDEX = 'index';
+    public const OPTION_BATCH_NUMBER = 'batch-number';
+    public const OPTION_LISTING_COUNT = 'listing-count';
+    public const OPTION_DOCUMENT = 'document';
+
+    public const COMMAND_NAMESPACE = 'valantic:elastica-bridge:';
+
+    public const COMMAND_INDEX = self::COMMAND_NAMESPACE . 'index';
+    public const COMMAND_CLEANUP = self::COMMAND_NAMESPACE . 'cleanup';
+    public const COMMAND_REFRESH = self::COMMAND_NAMESPACE . 'refresh';
+    public const COMMAND_STATUS = self::COMMAND_NAMESPACE . 'status';
+    public const COMMAND_POPULATE_INDEX = self::COMMAND_NAMESPACE . 'populate-index';
+    public const COMMAND_DO_POPULATE_INDEX = self::COMMAND_NAMESPACE . 'do-populate-index';
+}

--- a/src/Index/AbstractIndex.php
+++ b/src/Index/AbstractIndex.php
@@ -61,6 +61,11 @@ abstract class AbstractIndex implements IndexInterface
         return 5000;
     }
 
+    public function shouldPopulateInSubprocesses(): bool
+    {
+        return false;
+    }
+
     public function getElasticaIndex(): Index
     {
         return $this->client->getIndex($this->getName());

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -32,6 +32,14 @@ interface IndexInterface
     public function getBatchSize(): int;
 
     /**
+     * Defines if the the index should be populated in subprocesses.
+     * This is useful for large indexes to avoid memory issues.
+     *
+     * @return bool
+     */
+    public function shouldPopulateInSubprocesses(): bool;
+
+    /**
      * Defines the mapping to be used for this index.
      * Passed 1:1 to Elasticsearch.
      *


### PR DESCRIPTION
The current implementation crashes on huge indexes due to memory exhaustion.
This implementation adds the possibility to configure an index to be indexed in batched sub-processes to work around this issue.