### PR TITLE
[FEATURE] allow to setParams from dataObject->getParams in doPopulateIndex

### DIFF
--- a/src/Command/DoPopulateIndex.php
+++ b/src/Command/DoPopulateIndex.php
@@ -126,7 +126,17 @@ class DoPopulateIndex extends BaseCommand
                 }
                 $progressBar->advance();
 
-                $esDocuments[] = $this->documentHelper->elementToDocument($documentInstance, $dataObject);
+                $esDocument = $this->documentHelper->elementToDocument($documentInstance, $dataObject);
+
+                $params = $dataObject->getParams() ?? [];
+
+                if ($params !== []) {
+                    foreach ($params as $key => $value) {
+                        $esDocument->setParam($key, $value);
+                    }
+                }
+
+                $esDocuments[] = $esDocument;
             } catch (\Throwable $throwable) {
                 $this->displayDocumentError($indexConfig, $document, $dataObject, $throwable);
 


### PR DESCRIPTION
Allows to `setParams` in `doPopulateIndex`
This allows f.e. to set `routing` parameters while indexing documents, which is f.e. needed to establish `Parent:Child` relations when specifying `Join` fields on an Index